### PR TITLE
Added relativeSearch functionality

### DIFF
--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -72,8 +72,13 @@ class QuickOpenHandler(APIHandler):
             contents: File names binned by parent directory
         """
         excludes = set(self.get_arguments('excludes'))
+        current_path = self.get_argument('path')
         start_ts = time.time()
-        contents_by_path = self.scan_disk(self.root_dir, excludes)
+        if current_path:
+            full_path = os.path.join(self.root_dir, current_path)
+        else:
+            full_path = self.root_dir
+        contents_by_path = self.scan_disk(full_path, excludes)
         delta_ts = time.time() - start_ts
         self.write(json_encode({
             'scan_seconds': delta_ts,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@jupyterlab/apputils": "^1.0.0",
     "@jupyterlab/coreutils": "^3.0.0",
     "@jupyterlab/docmanager": "^1.0.0",
+    "@jupyterlab/filebrowser": "^1.0.1",
     "@jupyterlab/services": "^4.0.0",
     "@phosphor/messaging": "^1.2.3",
     "@phosphor/widgets": "^1.8.1"

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -10,6 +10,12 @@
       "type": "array",
       "items": { "type": "string" },
       "default": ["node_modules", "__pycache__"]
+    },
+    "relativeSearch": {
+      "title": "Relative Search",
+      "description": "Whether to search from currently selected directory",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Instead of always searching from the root directory, I created an option to search starting from the currently selected directory in the fileBrowser.

My use-case is that I want to be able to only search in my current project: with this option that is possible.