### PR TITLE
Update binder to use jupyter_server

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -14,5 +14,8 @@ WORKDIR ${HOME}
 RUN apt update \
     && apt install -q wamerican \
     && pip install --no-cache jupyterlab-quickopen \
-    && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+RUN cd $(dirname $(which jupyter-notebook)) \
+    && rm jupyter-notebook \
+    && ln -s jupyter-server jupyter-notebook

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -19,6 +19,8 @@ RUN apt update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+ADD tutorial.ipynb binder/tutorial.ipynb
+
 # As of 2020-12-31, force binder to use jupyter-server instead of jupyter-notebook
 RUN cd $(dirname $(which jupyter-notebook)) \
     && rm jupyter-notebook \

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR ${HOME}
 
 # Add project and demo dependencies
 RUN apt update \
-    && apt install -q wamerican procps \
+    && apt install -y -q wamerican procps \
     && pip install --no-cache jupyterlab-quickopen \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9-slim
+
+ARG NB_USER
+ARG NB_UID
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+WORKDIR ${HOME}
+
+RUN apt update \
+    && apt install -q wamerican \
+    && pip install --no-cache jupyterlab-quickopen \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,3 +1,4 @@
+# Based on https://mybinder.readthedocs.io/en/latest/examples/sample_repos.html#minimal-dockerfiles-for-binder
 FROM python:3.9-slim
 
 ARG NB_USER
@@ -11,11 +12,14 @@ RUN adduser --disabled-password \
     ${NB_USER}
 WORKDIR ${HOME}
 
+# Add project and demo dependencies
 RUN apt update \
-    && apt install -q wamerican \
+    && apt install -q wamerican procps \
     && pip install --no-cache jupyterlab-quickopen \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# As of 2020-12-31, force binder to use jupyter-server instead of jupyter-notebook
 RUN cd $(dirname $(which jupyter-notebook)) \
     && rm jupyter-notebook \
     && ln -s jupyter-server jupyter-notebook

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ADD tutorial.ipynb binder/tutorial.ipynb
+ADD . .
 
 # As of 2020-12-31, force binder to use jupyter-server instead of jupyter-notebook
 RUN cd $(dirname $(which jupyter-notebook)) \

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -19,9 +19,11 @@ RUN apt update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ADD . .
-
 # As of 2020-12-31, force binder to use jupyter-server instead of jupyter-notebook
 RUN cd $(dirname $(which jupyter-notebook)) \
     && rm jupyter-notebook \
     && ln -s jupyter-server jupyter-notebook
+
+# Add the entire source tree
+ADD . .
+RUN chown -R $NB_UID  .

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,0 @@
-wamerican

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,0 @@
-jupyterlab>=3.0,<4.0a
-jupyterlab-quickopen


### PR DESCRIPTION
Fix the binder example so that it uses jupyter_server instead of notebook so that the 1.0 extension works properly.