### PR TITLE
Support `.gitignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,36 +106,55 @@ Behavior when enabled:
 
 The setting works with both indexing modes (configured by `indexingMethod`, see below), with one caveat:
 
-- **Server mode** (default): works regardless of server configuration — `.gitignore` is read
-  directly from disk.
-- **Frontend mode** (used in JupyterLite and similar setups): the Jupyter Server must allow
-  listing hidden files, since `.gitignore` is itself a hidden file. Set
-  `ContentsManager.allow_hidden = True` in your `jupyter_server_config.py` (or pass
-  `--ContentsManager.allow_hidden=True` on the command line). Without this, the frontend cannot
-  see `.gitignore` files and the option silently has no effect.
+- **Server mode** (default): does not need additional server configuration; `.gitignore` is
+  read directly from disk.
+- **Frontend mode** (usually used in JupyterLite and similar setups): the Contents API must allow
+  listing hidden files, since `.gitignore` is itself a hidden file. For Jupyter Server-backed
+  Contents API deployments, set `ContentsManager.allow_hidden = True` in your
+  `jupyter_server_config.py` (or pass `--ContentsManager.allow_hidden=True` on the command line).
+  For prebuilt JupyterLite content, configure this at build time in `jupyter_lite_config.json` as
+  shown below. Without access to hidden files through the Contents API, the frontend cannot see
+  `.gitignore` files and the option silently has no effect.
 
 > [!TIP]
 > The gitignore feature works without showing `.gitignore` in the file browser. If you'd
 > also like to view or edit your `.gitignore` from JupyterLab, enable _Show Hidden Files_
-> from the _View_ menu (or the file browser's overflow menu) in addition to the server-side
-> `ContentsManager.allow_hidden` setting above.
+> from the _View_ menu (or the file browser's overflow menu). This UI setting is separate
+> from allowing hidden files through the Contents API.
 
 ### JupyterLite
 
 This extension is compatible with JupyterLite when using the client-side indexing mode. Open the
 _Advanced Settings Editor_ (_Settings → Advanced Settings Editor_), select the _Quick Open_ settings
-and set the `indexingMethod` to `"frontend"`. That enables the extension to index files via the
-JupyterLab Contents API on the client (suitable for JupyterLite deployments).
+and set the `indexingMethod` to `"frontend"`. To honor `.gitignore` files, also enable
+`respectGitignore`.
 
 You can add the following `overrides.json` file before building your JupyterLite site:
 
 ```json
 {
   "jupyterlab-quickopen:plugin": {
-    "indexingMethod": "frontend"
+    "indexingMethod": "frontend",
+    "respectGitignore": true
   }
 }
 ```
+
+If your JupyterLite site ships prebuilt content with `.gitignore` files, also include hidden files
+in the generated Contents API responses by adding the following `jupyter_lite_config.json` before
+building:
+
+```json
+{
+  "ContentsManager": {
+    "allow_hidden": true
+  }
+}
+```
+
+This is JupyterLite build configuration, not runtime `jupyter_server_config.py` configuration. The
+file browser still hides dotfiles by default; use the _Show Hidden Files_ setting only if you want
+users to see `.gitignore` in the file browser.
 
 ### Development install
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Behavior when enabled:
   [`ignore`](https://www.npmjs.com/package/ignore) on the frontend, both implementing
   `gitwildmatch` semantics including negation (`!pattern`) and directory-only patterns (`foo/`).
 
-The setting works with both indexing modes, with one caveat:
+The setting works with both indexing modes (configured by `indexingMethod`, see below), with one caveat:
 
 - **Server mode** (default): works regardless of server configuration — `.gitignore` is read
   directly from disk.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ of your choosing:
 
 ### Patterns to Exclude
 
-You can control which files to exclude from the quick open list using the Jupyter Server settings,
-JupyterLab settings, or both.
+You can control which files to exclude from the quick open list using JupyterLab settings. In
+Jupyter Server-backed deployments, Jupyter Server settings can also affect which files are listed.
 
-On the server side, use the `ContentsManager.allow_hidden` and/or `ContentsManager.hide_globs`
-settings. See the
+For server-backed deployments, use the `ContentsManager.allow_hidden` and/or
+`ContentsManager.hide_globs` settings. See the
 [documentation about Jupyter Server options](https://jupyter-server.readthedocs.io/en/latest/operators/configuring-extensions.html)
 for details.
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ The setting works with both indexing modes, with one caveat:
   `--ContentsManager.allow_hidden=True` on the command line). Without this, the frontend cannot
   see `.gitignore` files and the option silently has no effect.
 
+> [!TIP]
+> The gitignore feature works without showing `.gitignore` in the file browser. If you'd
+> also like to view or edit your `.gitignore` from JupyterLab, enable _Show Hidden Files_
+> from the _View_ menu (or the file browser's overflow menu) in addition to the server-side
+> `ContentsManager.allow_hidden` setting above.
+
 ### JupyterLite
 
 This extension is compatible with JupyterLite when using the client-side indexing mode. Open the

--- a/README.md
+++ b/README.md
@@ -81,6 +81,39 @@ area to override the default values.
 
 ![Screenshot of the quick open settings editor](./doc/settings.png)
 
+### Honoring `.gitignore`
+
+In addition to static exclude patterns, the extension can skip files and directories matched by
+`.gitignore` files in the workspace. The feature is opt-in — enable it in the _Quick Open_
+settings:
+
+```json
+{
+  "respectGitignore": true
+}
+```
+
+Behavior when enabled:
+
+- Each `.gitignore` is interpreted relative to the directory it lives in, mirroring git's own
+  semantics (e.g., `nested/.gitignore` only applies inside `nested/`).
+- The `.git` directory itself is always skipped (it isn't normally listed in `.gitignore`).
+- Only `.gitignore` files inside the scanned tree are honored. Global gitignore
+  (`~/.config/git/ignore`) and `.git/info/exclude` are not consulted.
+- Pattern matching uses [`pathspec`](https://pypi.org/project/pathspec/) on the server and
+  [`ignore`](https://www.npmjs.com/package/ignore) on the frontend, both implementing
+  `gitwildmatch` semantics including negation (`!pattern`) and directory-only patterns (`foo/`).
+
+The setting works with both indexing modes, with one caveat:
+
+- **Server mode** (default): works regardless of server configuration — `.gitignore` is read
+  directly from disk.
+- **Frontend mode** (used in JupyterLite and similar setups): the Jupyter Server must allow
+  listing hidden files, since `.gitignore` is itself a hidden file. Set
+  `ContentsManager.allow_hidden = True` in your `jupyter_server_config.py` (or pass
+  `--ContentsManager.allow_hidden=True` on the command line). Without this, the frontend cannot
+  see `.gitignore` files and the option silently has no effect.
+
 ### JupyterLite
 
 This extension is compatible with JupyterLite when using the client-side indexing mode. Open the

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,8 +5,12 @@ This directory contains configuration files for running a JupyterLite demo with 
 ## Files
 
 - `requirements.txt` - JupyterLite dependencies
-- `overrides.json` - Extension configuration to use frontend indexing method
+- `overrides.json` - JupyterLab settings for frontend indexing, `.gitignore` support, and showing
+  hidden files in the file browser
+- `jupyter_lite_config.json` - JupyterLite build configuration that includes hidden files in the
+  generated Contents API
 
 ## Usage
 
 Build and serve a JupyterLite instance with the quickopen extension configured for frontend-based file indexing.
+The demo is also configured to honor `.gitignore` files and show hidden files in the file browser.

--- a/demo/jupyter_lite_config.json
+++ b/demo/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+  "ContentsManager": {
+    "allow_hidden": true
+  }
+}

--- a/demo/overrides.json
+++ b/demo/overrides.json
@@ -1,5 +1,9 @@
 {
+  "@jupyterlab/filebrowser-extension:browser": {
+    "showHiddenFiles": true
+  },
   "jupyterlab-quickopen:plugin": {
-    "indexingMethod": "frontend"
+    "indexingMethod": "frontend",
+    "respectGitignore": true
   }
 }

--- a/jupyterlab_quickopen/__init__.py
+++ b/jupyterlab_quickopen/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from jupyter_server.utils import url_path_join
 
-from .handler import QuickOpenHandler
+from .handler import QuickOpenHandler, pathspec
 
 try:
     from ._version import __version__
@@ -57,3 +57,9 @@ def _load_jupyter_server_extension(server_app) -> None:
         f"Registered QuickOpenHandler extension at URL path {route_pattern} "
         f"to serve results of scanning local path {server_app.notebook_dir}"
     )
+    if pathspec is None:
+        server_app.log.warning(
+            "The 'pathspec' package is not installed; the 'respectGitignore' "
+            "setting will have no effect. Install with 'pip install pathspec' "
+            "to enable .gitignore filtering."
+        )

--- a/jupyterlab_quickopen/__init__.py
+++ b/jupyterlab_quickopen/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from jupyter_server.utils import url_path_join
 
-from .handler import QuickOpenHandler, pathspec
+from .handler import QuickOpenHandler
 
 try:
     from ._version import __version__
@@ -57,9 +57,3 @@ def _load_jupyter_server_extension(server_app) -> None:
         f"Registered QuickOpenHandler extension at URL path {route_pattern} "
         f"to serve results of scanning local path {server_app.notebook_dir}"
     )
-    if pathspec is None:
-        server_app.log.warning(
-            "The 'pathspec' package is not installed; the 'respectGitignore' "
-            "setting will have no effect. Install with 'pip install pathspec' "
-            "to enable .gitignore filtering."
-        )

--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -7,6 +7,14 @@ from jupyter_server.utils import ensure_async
 from tornado import web
 from tornado.escape import json_encode
 
+try:
+    import pathspec
+except ImportError:
+    pathspec = None
+
+
+GITIGNORE_FILENAME = ".gitignore"
+
 
 class QuickOpenHandler(APIHandler):
     @property
@@ -46,6 +54,52 @@ class QuickOpenHandler(APIHandler):
             )
         )
 
+    def _load_gitignore(self, directory: str):
+        """Read a .gitignore file in the given directory and return a PathSpec.
+
+        Returns None if no .gitignore exists, the file cannot be read, or
+        the pathspec library is not installed.
+        """
+        if pathspec is None:
+            return None
+        gitignore_path = os.path.join(directory, GITIGNORE_FILENAME)
+        if not os.path.isfile(gitignore_path):
+            return None
+        try:
+            with open(gitignore_path, "r", encoding="utf-8") as f:
+                return pathspec.PathSpec.from_lines("gitwildmatch", f)
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    def _matches_gitignore(self, specs: list, entry_path: str, is_dir: bool) -> bool:
+        """Return True if entry_path is ignored by the active .gitignore stack.
+
+        Specs are ordered outermost to innermost. Each spec's patterns are
+        interpreted relative to its base_dir, matching git's per-directory
+        .gitignore semantics: a deeper .gitignore can re-include a path that
+        a shallower one excluded (e.g. ``!important.log``).
+        """
+        ignored = False
+        for base_dir, spec in specs:
+            try:
+                rel = os.path.relpath(entry_path, base_dir)
+            except ValueError:
+                continue
+            if rel.startswith(".."):
+                continue
+            # pathspec's gitwildmatch expects POSIX-style separators
+            rel = rel.replace(os.sep, "/")
+            check_path = rel + "/" if is_dir else rel
+            result = spec.check_file(check_path)
+            # include=True  => matched a positive pattern (ignore)
+            # include=False => matched a negation pattern (re-include)
+            # include=None  => no pattern matched, leave state as-is
+            if result.include is True:
+                ignored = True
+            elif result.include is False:
+                ignored = False
+        return ignored
+
     async def scan_disk(
         self,
         path: str,
@@ -53,16 +107,42 @@ class QuickOpenHandler(APIHandler):
         on_disk: dict[str, list[str]] | None = None,
         max_depth: int | None = None,
         current_depth: int = 0,
+        respect_gitignore: bool = False,
+        gitignore_specs: list | None = None,
     ) -> dict[str, list[str]]:
         if on_disk is None:
             on_disk = {}
+        if gitignore_specs is None:
+            gitignore_specs = []
+
+        if respect_gitignore:
+            spec = self._load_gitignore(path)
+            if spec is not None:
+                gitignore_specs = gitignore_specs + [(path, spec)]
+
         if max_depth is not None and current_depth >= max_depth:
             return on_disk
         for entry in os.scandir(path):
+            is_dir = entry.is_dir()
+            if respect_gitignore and (
+                # The .git directory is not in .gitignore but should never be
+                # indexed when honoring git semantics.
+                (is_dir and entry.name == ".git")
+                or self._matches_gitignore(gitignore_specs, entry.path, is_dir)
+            ):
+                continue
             if await self.should_hide(entry, excludes):
                 continue
-            elif entry.is_dir():
-                await self.scan_disk(entry.path, excludes, on_disk, max_depth, current_depth + 1)
+            elif is_dir:
+                await self.scan_disk(
+                    entry.path,
+                    excludes,
+                    on_disk,
+                    max_depth,
+                    current_depth + 1,
+                    respect_gitignore=respect_gitignore,
+                    gitignore_specs=gitignore_specs,
+                )
             elif entry.is_file():
                 parent = os.path.relpath(os.path.dirname(entry.path), self.root_dir)
                 on_disk.setdefault(parent, []).append(entry.name)
@@ -77,6 +157,8 @@ class QuickOpenHandler(APIHandler):
         ---------
         exclude: str
             Comma-separated set of file name patterns to exclude
+        respect_gitignore: str
+            "1"/"true" to skip entries matching .gitignore patterns
 
         Responds
         --------
@@ -88,8 +170,16 @@ class QuickOpenHandler(APIHandler):
         current_path = self.get_argument("path")
         depth_arg = self.get_argument("depth", default=None)
         max_depth = int(depth_arg) if depth_arg is not None else None
+        respect_gitignore = self.get_argument(
+            "respect_gitignore", default=""
+        ).lower() in ("1", "true") and pathspec is not None
         start_ts = time.time()
         full_path = os.path.join(self.root_dir, current_path) if current_path else self.root_dir
-        contents_by_path = await self.scan_disk(full_path, excludes, max_depth=max_depth)
+        contents_by_path = await self.scan_disk(
+            full_path,
+            excludes,
+            max_depth=max_depth,
+            respect_gitignore=respect_gitignore,
+        )
         delta_ts = time.time() - start_ts
         self.write(json_encode({"scan_seconds": delta_ts, "contents": contents_by_path}))

--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -2,15 +2,11 @@ import os
 import time
 from fnmatch import fnmatch
 
+import pathspec
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import ensure_async
 from tornado import web
 from tornado.escape import json_encode
-
-try:
-    import pathspec
-except ImportError:
-    pathspec = None
 
 
 GITIGNORE_FILENAME = ".gitignore"
@@ -57,11 +53,8 @@ class QuickOpenHandler(APIHandler):
     def _load_gitignore(self, directory: str):
         """Read a .gitignore file in the given directory and return a PathSpec.
 
-        Returns None if no .gitignore exists, the file cannot be read, or
-        the pathspec library is not installed.
+        Returns None if no .gitignore exists or the file cannot be read.
         """
-        if pathspec is None:
-            return None
         gitignore_path = os.path.join(directory, GITIGNORE_FILENAME)
         if not os.path.isfile(gitignore_path):
             return None
@@ -90,14 +83,11 @@ class QuickOpenHandler(APIHandler):
             # pathspec's gitwildmatch expects POSIX-style separators
             rel = rel.replace(os.sep, "/")
             check_path = rel + "/" if is_dir else rel
+            # include is True (positive match), False (negation/re-include),
+            # or None (no pattern matched — leave state as-is).
             result = spec.check_file(check_path)
-            # include=True  => matched a positive pattern (ignore)
-            # include=False => matched a negation pattern (re-include)
-            # include=None  => no pattern matched, leave state as-is
-            if result.include is True:
-                ignored = True
-            elif result.include is False:
-                ignored = False
+            if result.include is not None:
+                ignored = result.include
         return ignored
 
     async def scan_disk(
@@ -172,7 +162,7 @@ class QuickOpenHandler(APIHandler):
         max_depth = int(depth_arg) if depth_arg is not None else None
         respect_gitignore = self.get_argument(
             "respect_gitignore", default=""
-        ).lower() in ("1", "true") and pathspec is not None
+        ).lower() in ("1", "true")
         start_ts = time.time()
         full_path = os.path.join(self.root_dir, current_path) if current_path else self.root_dir
         contents_by_path = await self.scan_disk(

--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -162,7 +162,14 @@ class QuickOpenHandler(APIHandler):
             "respect_gitignore", default=""
         ).lower() in ("1", "true")
         start_ts = time.time()
-        full_path = os.path.join(self.root_dir, current_path) if current_path else self.root_dir
+        root_dir = os.path.abspath(self.root_dir)
+        if current_path and os.path.splitdrive(current_path)[0]:
+            raise web.HTTPError(404, f"{current_path} is not a relative path")
+        full_path = os.path.abspath(os.path.join(root_dir, current_path))
+        if os.path.dirname(root_dir) != root_dir and not (full_path + os.sep).startswith(
+            root_dir + os.sep
+        ):
+            raise web.HTTPError(404, f"{current_path} is outside the root contents directory")
         contents_by_path = await self.scan_disk(
             full_path,
             excludes,

--- a/jupyterlab_quickopen/handler.py
+++ b/jupyterlab_quickopen/handler.py
@@ -50,21 +50,24 @@ class QuickOpenHandler(APIHandler):
             )
         )
 
-    def _load_gitignore(self, directory: str):
+    def _load_gitignore(self, directory: str) -> pathspec.PathSpec | None:
         """Read a .gitignore file in the given directory and return a PathSpec.
 
         Returns None if no .gitignore exists or the file cannot be read.
         """
         gitignore_path = os.path.join(directory, GITIGNORE_FILENAME)
-        if not os.path.isfile(gitignore_path):
-            return None
         try:
             with open(gitignore_path, "r", encoding="utf-8") as f:
                 return pathspec.PathSpec.from_lines("gitwildmatch", f)
         except (OSError, UnicodeDecodeError):
             return None
 
-    def _matches_gitignore(self, specs: list, entry_path: str, is_dir: bool) -> bool:
+    def _matches_gitignore(
+        self,
+        specs: list[tuple[str, pathspec.PathSpec]],
+        entry_path: str,
+        is_dir: bool,
+    ) -> bool:
         """Return True if entry_path is ignored by the active .gitignore stack.
 
         Specs are ordered outermost to innermost. Each spec's patterns are
@@ -74,14 +77,8 @@ class QuickOpenHandler(APIHandler):
         """
         ignored = False
         for base_dir, spec in specs:
-            try:
-                rel = os.path.relpath(entry_path, base_dir)
-            except ValueError:
-                continue
-            if rel.startswith(".."):
-                continue
             # pathspec's gitwildmatch expects POSIX-style separators
-            rel = rel.replace(os.sep, "/")
+            rel = os.path.relpath(entry_path, base_dir).replace(os.sep, "/")
             check_path = rel + "/" if is_dir else rel
             # include is True (positive match), False (negation/re-include),
             # or None (no pattern matched — leave state as-is).
@@ -98,20 +95,21 @@ class QuickOpenHandler(APIHandler):
         max_depth: int | None = None,
         current_depth: int = 0,
         respect_gitignore: bool = False,
-        gitignore_specs: list | None = None,
+        gitignore_specs: list[tuple[str, pathspec.PathSpec]] | None = None,
     ) -> dict[str, list[str]]:
         if on_disk is None:
             on_disk = {}
         if gitignore_specs is None:
             gitignore_specs = []
 
+        if max_depth is not None and current_depth >= max_depth:
+            return on_disk
+
         if respect_gitignore:
             spec = self._load_gitignore(path)
             if spec is not None:
                 gitignore_specs = gitignore_specs + [(path, spec)]
 
-        if max_depth is not None and current_depth >= max_depth:
-            return on_disk
         for entry in os.scandir(path):
             is_dir = entry.is_dir()
             if respect_gitignore and (

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
         "@lumino/disposable": "^2.0.0",
         "@lumino/messaging": "^2.0.0",
         "@lumino/signaling": "^2.0.0",
-        "@lumino/widgets": "^2.0.0"
+        "@lumino/widgets": "^2.0.0",
+        "ignore": "^5.3.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "jupyter_server>=2.4.2,<3"
+    "jupyter_server>=2.4.2,<3",
+    "pathspec>=0.10"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -44,7 +44,7 @@
     },
     "respectGitignore": {
       "title": "Respect .gitignore",
-      "description": "Skip files and directories matched by .gitignore patterns. In 'frontend' indexing mode this requires the Jupyter Server to allow listing hidden files (ContentsManager.allow_hidden=True), since .gitignore files are themselves hidden.",
+      "description": "Skip files and directories matched by .gitignore patterns. In 'frontend' indexing mode, .gitignore files can only be honored when the Contents API exposes hidden files. For Jupyter Server this means ContentsManager.allow_hidden=True; for prebuilt JupyterLite content this is configured at build time in jupyter_lite_config.json.",
       "type": "boolean",
       "default": false
     }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -41,6 +41,12 @@
       "type": "number",
       "minimum": 1,
       "default": 20
+    },
+    "respectGitignore": {
+      "title": "Respect .gitignore",
+      "description": "Skip files and directories matched by .gitignore patterns. In 'frontend' indexing mode this requires the Jupyter Server to allow listing hidden files (ContentsManager.allow_hidden=True), since .gitignore files are themselves hidden.",
+      "type": "boolean",
+      "default": false
     }
   },
   "jupyter.lab.menus": {

--- a/src/frontendProvider.ts
+++ b/src/frontendProvider.ts
@@ -1,10 +1,21 @@
 import { PathExt } from '@jupyterlab/coreutils';
 import { Contents } from '@jupyterlab/services';
+import ignore, { Ignore } from 'ignore';
 import {
   IQuickOpenOptions,
   IQuickOpenProvider,
   IQuickOpenResponse
 } from './tokens';
+
+const GITIGNORE_FILENAME = '.gitignore';
+
+/**
+ * A parsed .gitignore associated with the directory it lives in.
+ */
+interface IGitignoreSpec {
+  baseDir: string;
+  ig: Ignore;
+}
 
 /**
  * Frontend implementation of the quick open provider that uses the Contents API.
@@ -24,13 +35,21 @@ export class FrontendQuickOpenProvider implements IQuickOpenProvider {
    * @returns Promise resolving to contents and scan time
    */
   async fetchContents(options: IQuickOpenOptions): Promise<IQuickOpenResponse> {
-    const { path, excludes, depth } = options;
+    const { path, excludes, depth, respectGitignore } = options;
     const startTime = performance.now();
     const contents: { [key: string]: string[] } = {};
 
     try {
       const maxDepth = depth ?? Infinity;
-      await this._walkDirectory(path, excludes, contents, maxDepth);
+      await this._walkDirectory(
+        path,
+        excludes,
+        contents,
+        maxDepth,
+        0,
+        [],
+        respectGitignore ?? false
+      );
     } catch (error) {
       console.warn('Error walking directory:', error);
     }
@@ -46,13 +65,17 @@ export class FrontendQuickOpenProvider implements IQuickOpenProvider {
    * @param contents Object to accumulate results in
    * @param maxDepth Maximum recursion depth
    * @param currentDepth Current recursion depth
+   * @param gitignoreSpecs Active .gitignore specs inherited from ancestor directories
+   * @param respectGitignore Whether to honor .gitignore files
    */
   private async _walkDirectory(
     dirPath: string,
     excludes: string[],
     contents: { [key: string]: string[] },
     maxDepth: number = Infinity,
-    currentDepth: number = 0
+    currentDepth: number = 0,
+    gitignoreSpecs: IGitignoreSpec[] = [],
+    respectGitignore: boolean = false
   ): Promise<void> {
     if (currentDepth >= maxDepth) {
       return;
@@ -68,25 +91,41 @@ export class FrontendQuickOpenProvider implements IQuickOpenProvider {
         return;
       }
 
+      let activeSpecs = gitignoreSpecs;
+      if (respectGitignore) {
+        const spec = await this._loadGitignore(dirPath, listing.content);
+        if (spec) {
+          activeSpecs = [...gitignoreSpecs, spec];
+        }
+      }
+
       for (const item of listing.content) {
         const itemPath = dirPath ? PathExt.join(dirPath, item.name) : item.name;
+        const isDir = item.type === 'directory';
 
-        // Check if item should be excluded
+        if (
+          respectGitignore &&
+          ((isDir && item.name === '.git') ||
+            this._matchesGitignore(activeSpecs, itemPath, isDir))
+        ) {
+          continue;
+        }
+
         if (this._shouldExclude(item.name, itemPath, excludes)) {
           continue;
         }
 
-        if (item.type === 'directory') {
-          // Recursively walk subdirectories
+        if (isDir) {
           await this._walkDirectory(
             itemPath,
             excludes,
             contents,
             maxDepth,
-            currentDepth + 1
+            currentDepth + 1,
+            activeSpecs,
+            respectGitignore
           );
         } else {
-          // Add file to contents under its directory category
           const category = dirPath || '.';
           if (!contents[category]) {
             contents[category] = [];
@@ -98,6 +137,75 @@ export class FrontendQuickOpenProvider implements IQuickOpenProvider {
       // Silently skip directories we can't access
       console.debug(`Skipping directory ${dirPath}:`, error);
     }
+  }
+
+  /**
+   * Read the .gitignore file in the given directory if listed, and parse it.
+   *
+   * Requires the server's ContentsManager to allow listing hidden files
+   * (allow_hidden=True) since .gitignore is dot-prefixed; if it isn't visible
+   * in the directory listing, no spec is returned.
+   */
+  private async _loadGitignore(
+    dirPath: string,
+    items: Contents.IModel[]
+  ): Promise<IGitignoreSpec | null> {
+    const entry = items.find(
+      item => item.name === GITIGNORE_FILENAME && item.type === 'file'
+    );
+    if (!entry) {
+      return null;
+    }
+    const itemPath = dirPath
+      ? PathExt.join(dirPath, GITIGNORE_FILENAME)
+      : GITIGNORE_FILENAME;
+    try {
+      const file = await this._contentsManager.get(itemPath, {
+        content: true,
+        format: 'text',
+        type: 'file'
+      });
+      const text =
+        typeof file.content === 'string' ? file.content : String(file.content);
+      const ig = ignore().add(text);
+      return { baseDir: dirPath || '.', ig };
+    } catch (error) {
+      console.debug(`Could not read ${itemPath}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Check whether an item path is ignored by the active .gitignore stack.
+   *
+   * Specs are ordered outermost to innermost. Each spec is interpreted
+   * relative to the directory it came from, matching git's per-directory
+   * .gitignore semantics: a deeper .gitignore can re-include a path that
+   * a shallower one excluded (e.g. `!important.log`).
+   */
+  private _matchesGitignore(
+    specs: IGitignoreSpec[],
+    itemPath: string,
+    isDir: boolean
+  ): boolean {
+    let ignored = false;
+    for (const { baseDir, ig } of specs) {
+      const rel =
+        baseDir === '.' ? itemPath : PathExt.relative(baseDir, itemPath);
+      if (!rel || rel.startsWith('..')) {
+        continue;
+      }
+      const candidate = isDir ? rel + '/' : rel;
+      const result = ig.test(candidate);
+      // ignored:   matched a positive pattern in this spec
+      // unignored: matched a negation pattern in this spec
+      if (result.ignored) {
+        ignored = true;
+      } else if (result.unignored) {
+        ignored = false;
+      }
+    }
+    return ignored;
   }
 
   /**

--- a/src/frontendProvider.ts
+++ b/src/frontendProvider.ts
@@ -142,9 +142,9 @@ export class FrontendQuickOpenProvider implements IQuickOpenProvider {
   /**
    * Read the .gitignore file in the given directory if listed, and parse it.
    *
-   * Requires the server's ContentsManager to allow listing hidden files
-   * (allow_hidden=True) since .gitignore is dot-prefixed; if it isn't visible
-   * in the directory listing, no spec is returned.
+   * Requires the Contents API to expose hidden files since .gitignore is
+   * dot-prefixed; if it isn't visible in the directory listing, no spec is
+   * returned.
    */
   private async _loadGitignore(
     dirPath: string,

--- a/src/serverProvider.ts
+++ b/src/serverProvider.ts
@@ -14,13 +14,17 @@ export class ServerQuickOpenProvider implements IQuickOpenProvider {
    * Fetch contents from the server endpoint.
    */
   async fetchContents(options: IQuickOpenOptions): Promise<IQuickOpenResponse> {
-    const { path, excludes, depth } = options;
+    const { path, excludes, depth, respectGitignore } = options;
     const queryParams = excludes.map(
       exclude => 'excludes=' + encodeURIComponent(exclude)
     );
 
     if (depth !== undefined && depth !== Infinity) {
       queryParams.push('depth=' + depth);
+    }
+
+    if (respectGitignore) {
+      queryParams.push('respect_gitignore=1');
     }
 
     const query = queryParams.join('&');

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -16,9 +16,8 @@ export interface IQuickOpenOptions {
   depth?: number;
   /**
    * Whether to skip entries matched by .gitignore files.
-   * In frontend indexing mode this requires the Jupyter Server to allow
-   * listing hidden files (ContentsManager.allow_hidden=True), since
-   * .gitignore files are themselves hidden.
+   * In frontend indexing mode this requires the Contents API to expose
+   * hidden files, since .gitignore files are themselves hidden.
    */
   respectGitignore?: boolean;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -14,6 +14,13 @@ export interface IQuickOpenOptions {
   excludes: string[];
   /** Maximum directory depth to search (Infinity for unlimited) */
   depth?: number;
+  /**
+   * Whether to skip entries matched by .gitignore files.
+   * In frontend indexing mode this requires the Jupyter Server to allow
+   * listing hidden files (ContentsManager.allow_hidden=True), since
+   * .gitignore files are themselves hidden.
+   */
+  respectGitignore?: boolean;
 }
 
 /** Interface for quick open content providers */

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -69,7 +69,8 @@ export class QuickOpenWidget extends CommandPalette {
     const response = await this._provider.fetchContents({
       path,
       excludes: this._settings.excludes as string[],
-      depth: depth
+      depth: depth,
+      respectGitignore: this._settings.respectGitignore as boolean
     });
 
     // Clean up previous commands and remove all paths from the view

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,7 +2930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0, ignore@npm:^5.2.4":
+"ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.0":
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 2acfd32a573260ea522ea0bfeff880af426d68f6831f973129e2ba7363f422923cf53aab62f8369cbf4667c7b25b6f8a3761b34ecdb284ea18e87a5262a865be
@@ -3412,6 +3412,7 @@ __metadata:
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0
+    ignore: ^5.3.0
     mkdirp: ^1.0.3
     npm-run-all: ^4.1.5
     prettier: ^3.0.0


### PR DESCRIPTION
Fixes https://github.com/jupyterlab-contrib/jupyterlab-quickopen/issues/7

Opt-in since it also requires Jupyter Server to be configure to allow hidden files.

https://github.com/user-attachments/assets/0dc08d8e-3443-44e7-9a4d-b697c1d0638f


