### PR TITLE
Show folder in the search palette

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -48,6 +48,7 @@ export class QuickOpenWidget extends CommandPalette {
     super({ renderer: new QuickOpenRenderer(), ...options });
 
     this.id = 'jupyterlab-quickopen';
+    this.addClass('jp-QuickOpen');
     this.title.iconClass = 'jp-SideBar-tabIcon jp-SearchIcon';
     this.title.caption = 'Quick Open';
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -3,8 +3,34 @@ import { ReadonlyPartialJSONObject } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
 import { Message } from '@lumino/messaging';
 import { ISignal, Signal } from '@lumino/signaling';
+import { h, VirtualElement } from '@lumino/virtualdom';
 import { CommandPalette } from '@lumino/widgets';
 import { IQuickOpenProvider } from './tokens';
+
+/**
+ * The CSS class added to the inline parent directory next to the filename.
+ */
+const ITEM_PATH_CLASS = 'jp-QuickOpen-itemPath';
+
+/**
+ * A renderer that shows the parent directory inline next to the filename,
+ * styled like VS Code's quick open palette so files with the same name in
+ * different folders can be told apart.
+ */
+class QuickOpenRenderer extends CommandPalette.Renderer {
+  renderItemContent(data: CommandPalette.IItemRenderData): VirtualElement {
+    const path = data.item.caption;
+    const label = this.renderItemLabel(data);
+    if (!path || path === '.') {
+      return h.div({ className: 'lm-CommandPalette-itemContent' }, label);
+    }
+    return h.div(
+      { className: 'lm-CommandPalette-itemContent' },
+      label,
+      h.div({ className: ITEM_PATH_CLASS, title: path }, path)
+    );
+  }
+}
 
 /**
  * Shows files nested under directories in the root notebooks directory configured on the server.
@@ -19,7 +45,7 @@ export class QuickOpenWidget extends CommandPalette {
     provider: IQuickOpenProvider,
     options: CommandPalette.IOptions
   ) {
-    super(options);
+    super({ renderer: new QuickOpenRenderer(), ...options });
 
     this.id = 'jupyterlab-quickopen';
     this.title.iconClass = 'jp-SideBar-tabIcon jp-SearchIcon';
@@ -85,6 +111,7 @@ export class QuickOpenWidget extends CommandPalette {
         if (!this.commands.hasCommand(command)) {
           const disposable = this.commands.addCommand(command, {
             label: fn,
+            caption: category,
             execute: () => {
               // Emit a selection signal
               this._pathSelected.emit(command);

--- a/style/base.css
+++ b/style/base.css
@@ -1,3 +1,38 @@
 .jp-SearchIcon {
   background-image: var(--jp-icon-search);
 }
+
+/*
+ * Show the parent directory inline next to the filename, in a lighter,
+ * smaller font, so files with the same name in different folders can be
+ * told apart.
+ */
+.lm-CommandPalette-itemContent {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.lm-CommandPalette-itemContent .lm-CommandPalette-itemLabel {
+  flex: 0 0 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 60%;
+}
+
+.jp-QuickOpen-itemPath {
+  flex: 0 1 auto;
+  min-width: 0;
+  margin-left: 8px;
+  color: var(--jp-ui-font-color2);
+  font-size: var(--jp-ui-font-size0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lm-CommandPalette-item.lm-mod-active .jp-QuickOpen-itemPath {
+  color: var(--jp-ui-inverse-font-color2);
+}

--- a/style/base.css
+++ b/style/base.css
@@ -14,7 +14,7 @@
   min-width: 0;
 }
 
-.jp-QuickOpen .lm-CommandPalette-itemContent .lm-CommandPalette-itemLabel {
+.jp-QuickOpen .lm-CommandPalette-itemContent > .lm-CommandPalette-itemLabel {
   flex: 0 0 auto;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -22,7 +22,7 @@
   max-width: 60%;
 }
 
-.jp-QuickOpen .jp-QuickOpen-itemPath {
+.jp-QuickOpen-itemPath {
   flex: 0 1 auto;
   min-width: 0;
   margin-left: 8px;

--- a/style/base.css
+++ b/style/base.css
@@ -7,14 +7,14 @@
  * smaller font, so files with the same name in different folders can be
  * told apart.
  */
-.lm-CommandPalette-itemContent {
+.jp-QuickOpen .lm-CommandPalette-itemContent {
   display: flex;
   flex-direction: row;
   align-items: baseline;
   min-width: 0;
 }
 
-.lm-CommandPalette-itemContent .lm-CommandPalette-itemLabel {
+.jp-QuickOpen .lm-CommandPalette-itemContent .lm-CommandPalette-itemLabel {
   flex: 0 0 auto;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -22,7 +22,7 @@
   max-width: 60%;
 }
 
-.jp-QuickOpen-itemPath {
+.jp-QuickOpen .jp-QuickOpen-itemPath {
   flex: 0 1 auto;
   min-width: 0;
   margin-left: 8px;
@@ -33,6 +33,6 @@
   white-space: nowrap;
 }
 
-.lm-CommandPalette-item.lm-mod-active .jp-QuickOpen-itemPath {
+.jp-QuickOpen .lm-CommandPalette-item.lm-mod-active .jp-QuickOpen-itemPath {
   color: var(--jp-ui-inverse-font-color2);
 }


### PR DESCRIPTION
Fixes https://github.com/jupyterlab-contrib/jupyterlab-quickopen/issues/86

Currently this does not highlight the matched part in the folder path, but this could be investigated separately.

<img width="1816" height="820" alt="image" src="https://github.com/user-attachments/assets/68d0f752-0b88-4e7f-8b9f-575268e7e2ea" />

